### PR TITLE
Feature/polygon rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Build Status
 ------------
 
 [![PyPi Version](https://img.shields.io/pypi/v/SciStag.svg)](https://pypi.python.org/pypi/SciStag)
-![](https://shields.io/badge/Python-3.9%20%7C%203.10-blue)
+![](https://shields.io/badge/Python-3.9%20%7C%203.10%20%7C%203.11-blue)
 [![Documentation Status](https://readthedocs.org/projects/scistag/badge/?version=latest)](https://scistag.readthedocs.io/en/latest/?badge=latest)
 [![Coverage](https://coveralls.io/repos/github/SciStag/SciStag/badge.svg?branch=main)](https://coveralls.io/github/SciStag/SciStag)
 [![Pylint](https://raw.githubusercontent.com/SciStag/SciStag/v0.0.3/docs/source/generated/pylint.svg)](https://coveralls.io/github/SciStag/SciStag)

--- a/poetry.lock
+++ b/poetry.lock
@@ -84,11 +84,14 @@ python-versions = ">=3.7.2"
 [package.dependencies]
 lazy-object-proxy = ">=1.4.0"
 typing-extensions = {version = ">=3.10", markers = "python_version < \"3.10\""}
-wrapt = {version = ">=1.11,<2", markers = "python_version < \"3.11\""}
+wrapt = [
+    {version = ">=1.11,<2", markers = "python_version < \"3.11\""},
+    {version = ">=1.14,<2", markers = "python_version >= \"3.11\""},
+]
 
 [[package]]
 name = "asttokens"
-version = "2.2.0"
+version = "2.2.1"
 description = "Annotate AST trees with source code positions"
 category = "main"
 optional = true
@@ -465,15 +468,15 @@ devel = ["colorama", "json-spec", "jsonschema", "pylint", "pytest", "pytest-benc
 
 [[package]]
 name = "filelock"
-version = "3.8.0"
+version = "3.8.2"
 description = "A platform independent file lock."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo (>=2022.6.21)", "sphinx (>=5.1.1)", "sphinx-autodoc-typehints (>=1.19.1)"]
-testing = ["covdefaults (>=2.2)", "coverage (>=6.4.2)", "pytest (>=7.1.2)", "pytest-cov (>=3)", "pytest-timeout (>=2.1)"]
+docs = ["furo (>=2022.9.29)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.5)"]
+testing = ["covdefaults (>=2.2.2)", "coverage (>=6.5)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-timeout (>=2.1)"]
 
 [[package]]
 name = "filetype"
@@ -842,7 +845,7 @@ qtconsole = "*"
 
 [[package]]
 name = "jupyter-client"
-version = "7.4.7"
+version = "7.4.8"
 description = "Jupyter protocol implementation and client libraries"
 category = "main"
 optional = true
@@ -927,7 +930,7 @@ test = ["coverage", "ipykernel", "pre-commit", "pytest (>=7.0)", "pytest-console
 
 [[package]]
 name = "jupyterlab"
-version = "3.5.0"
+version = "3.5.1"
 description = "JupyterLab computational environment"
 category = "main"
 optional = true
@@ -1151,7 +1154,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "mdit-py-plugins"
-version = "0.3.1"
+version = "0.3.3"
 description = "Collection of plugins for markdown-it-py"
 category = "dev"
 optional = false
@@ -1300,7 +1303,7 @@ test = ["ipykernel", "ipython", "ipywidgets", "nbconvert (>=7.0.0)", "pytest (>=
 
 [[package]]
 name = "nbconvert"
-version = "7.2.5"
+version = "7.2.6"
 description = "Converting Jupyter Notebooks"
 category = "main"
 optional = true
@@ -1325,12 +1328,12 @@ tinycss2 = "*"
 traitlets = ">=5.0"
 
 [package.extras]
-all = ["ipykernel", "ipython", "ipywidgets (>=7)", "myst-parser", "nbsphinx (>=0.2.12)", "pre-commit", "pyppeteer (>=1,<1.1)", "pyqtwebengine (>=5.15)", "pytest", "pytest-cov", "pytest-dependency", "sphinx (==5.0.2)", "sphinx-rtd-theme", "tornado (>=6.1)"]
-docs = ["ipython", "myst-parser", "nbsphinx (>=0.2.12)", "sphinx (==5.0.2)", "sphinx-rtd-theme"]
-qtpdf = ["pyqtwebengine (>=5.15)"]
+all = ["nbconvert[docs,qtpdf,serve,test,webpdf]"]
+docs = ["ipykernel", "ipython", "myst-parser", "nbsphinx (>=0.2.12)", "pydata-sphinx-theme", "sphinx (==5.0.2)"]
+qtpdf = ["nbconvert[qtpng]"]
 qtpng = ["pyqtwebengine (>=5.15)"]
 serve = ["tornado (>=6.1)"]
-test = ["ipykernel", "ipywidgets (>=7)", "pre-commit", "pyppeteer (>=1,<1.1)", "pytest", "pytest-cov", "pytest-dependency"]
+test = ["ipykernel", "ipywidgets (>=7)", "pre-commit", "pyppeteer (>=1,<1.1)", "pytest", "pytest-dependency"]
 webpdf = ["pyppeteer (>=1,<1.1)"]
 
 [[package]]
@@ -1473,6 +1476,7 @@ python-versions = ">=3.8"
 [package.dependencies]
 numpy = [
     {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
+    {version = ">=1.23.2", markers = "python_version >= \"3.11\""},
     {version = ">=1.20.3", markers = "python_version < \"3.10\""},
 ]
 python-dateutil = ">=2.8.1"
@@ -1656,7 +1660,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pyarrow"
-version = "9.0.0"
+version = "10.0.1"
 description = "Python library for Apache Arrow"
 category = "main"
 optional = true
@@ -1701,7 +1705,7 @@ plugins = ["importlib-metadata"]
 
 [[package]]
 name = "pylint"
-version = "2.15.7"
+version = "2.15.8"
 description = "python code static checker"
 category = "dev"
 optional = false
@@ -2237,7 +2241,7 @@ widechars = ["wcwidth"]
 
 [[package]]
 name = "terminado"
-version = "0.17.0"
+version = "0.17.1"
 description = "Tornado websocket backend for the Xterm.js Javascript terminal emulator library."
 category = "main"
 optional = true
@@ -2249,7 +2253,7 @@ pywinpty = {version = ">=1.1.0", markers = "os_name == \"nt\""}
 tornado = ">=6.1.0"
 
 [package.extras]
-docs = ["pydata-sphinx-theme", "sphinx"]
+docs = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
 test = ["pre-commit", "pytest (>=7.0)", "pytest-timeout"]
 
 [[package]]
@@ -2351,7 +2355,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.17.0"
+version = "20.17.1"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -2453,8 +2457,8 @@ svg = ["CairoSVG"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.9 <=3.10"
-content-hash = "2862128bc472d9441281e1cd134a9ad4cf521a3ae3c1a5a039ec7f78f92b1ba3"
+python-versions = ">=3.9 <3.12"
+content-hash = "837f46fb848949bd73e5657d05187e1c393a2237e00adae199dee76213372a6d"
 
 [metadata.files]
 alabaster = [
@@ -2505,8 +2509,8 @@ astroid = [
     {file = "astroid-2.12.13.tar.gz", hash = "sha256:1493fe8bd3dfd73dc35bd53c9d5b6e49ead98497c47b2307662556a5692d29d7"},
 ]
 asttokens = [
-    {file = "asttokens-2.2.0-py2.py3-none-any.whl", hash = "sha256:c56caef774a929923696f09ceea0eadcb95c94b30e8ee4f9fc4f5867096caaeb"},
-    {file = "asttokens-2.2.0.tar.gz", hash = "sha256:e27b1f115daebfafd4d1826fc75f9a72f0b74bd3ae4ee4d9380406d74d35e52c"},
+    {file = "asttokens-2.2.1-py2.py3-none-any.whl", hash = "sha256:6b0ac9e93fb0335014d382b8fa9b3afa7df546984258005da0b9e7095b3deb1c"},
+    {file = "asttokens-2.2.1.tar.gz", hash = "sha256:4622110b2a6f30b77e1473affaa97e711bc2f07d3f10848420ff1898edbe94f3"},
 ]
 attrs = [
     {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
@@ -2849,8 +2853,8 @@ fastjsonschema = [
     {file = "fastjsonschema-2.16.2.tar.gz", hash = "sha256:01e366f25d9047816fe3d288cbfc3e10541daf0af2044763f3d0ade42476da18"},
 ]
 filelock = [
-    {file = "filelock-3.8.0-py3-none-any.whl", hash = "sha256:617eb4e5eedc82fc5f47b6d61e4d11cb837c56cb4544e39081099fa17ad109d4"},
-    {file = "filelock-3.8.0.tar.gz", hash = "sha256:55447caa666f2198c5b6b13a26d2084d26fa5b115c00d065664b2124680c4edc"},
+    {file = "filelock-3.8.2-py3-none-any.whl", hash = "sha256:8df285554452285f79c035efb0c861eb33a4bcfa5b7a137016e32e6a90f9792c"},
+    {file = "filelock-3.8.2.tar.gz", hash = "sha256:7565f628ea56bfcd8e54e42bdc55da899c85c1abfe1b5bcfd147e9188cebb3b2"},
 ]
 filetype = [
     {file = "filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25"},
@@ -2958,8 +2962,8 @@ jupyter = [
     {file = "jupyter-1.0.0.zip", hash = "sha256:3e1f86076bbb7c8c207829390305a2b1fe836d471ed54be66a3b8c41e7f46cc7"},
 ]
 jupyter-client = [
-    {file = "jupyter_client-7.4.7-py3-none-any.whl", hash = "sha256:df56ae23b8e1da1b66f89dee1368e948b24a7f780fa822c5735187589fc4c157"},
-    {file = "jupyter_client-7.4.7.tar.gz", hash = "sha256:330f6b627e0b4bf2f54a3a0dd9e4a22d2b649c8518168afedce2c96a1ceb2860"},
+    {file = "jupyter_client-7.4.8-py3-none-any.whl", hash = "sha256:d4a67ae86ee014bcb96bd8190714f6af921f2b0f52f4208b086aa5acfd9f8d65"},
+    {file = "jupyter_client-7.4.8.tar.gz", hash = "sha256:109a3c33b62a9cf65aa8325850a0999a795fac155d9de4f7555aef5f310ee35a"},
 ]
 jupyter-console = [
     {file = "jupyter_console-6.4.4-py3-none-any.whl", hash = "sha256:756df7f4f60c986e7bc0172e4493d3830a7e6e75c08750bbe59c0a5403ad6dee"},
@@ -2974,8 +2978,8 @@ jupyter-server = [
     {file = "jupyter_server-1.23.3.tar.gz", hash = "sha256:f7f7a2f9d36f4150ad125afef0e20b1c76c8ff83eb5e39fb02d3b9df0f9b79ab"},
 ]
 jupyterlab = [
-    {file = "jupyterlab-3.5.0-py3-none-any.whl", hash = "sha256:f433059fe0e12d75ea90a81a0b6721113bb132857e3ec2197780b6fe84cbcbde"},
-    {file = "jupyterlab-3.5.0.tar.gz", hash = "sha256:e02556c8ea1b386963c4b464e4618aee153c5416b07ab481425c817a033323a2"},
+    {file = "jupyterlab-3.5.1-py3-none-any.whl", hash = "sha256:c6748b4f21850c0095ed2187ce86d7e06edd9d1180cc4e6a572c4013163c0c74"},
+    {file = "jupyterlab-3.5.1.tar.gz", hash = "sha256:59a1b2d79d4b3ebee4d997c8bed8cf450f460c7c35f46b613a93f0b7712b47fc"},
 ]
 jupyterlab-pygments = [
     {file = "jupyterlab_pygments-0.2.2-py2.py3-none-any.whl", hash = "sha256:2405800db07c9f770863bcf8049a529c3dd4d3e28536638bd7c1c01d2748309f"},
@@ -3241,8 +3245,8 @@ mccabe = [
     {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
 ]
 mdit-py-plugins = [
-    {file = "mdit-py-plugins-0.3.1.tar.gz", hash = "sha256:3fc13298497d6e04fe96efdd41281bfe7622152f9caa1815ea99b5c893de9441"},
-    {file = "mdit_py_plugins-0.3.1-py3-none-any.whl", hash = "sha256:606a7f29cf56dbdfaf914acb21709b8f8ee29d857e8f29dcc33d8cb84c57bfa1"},
+    {file = "mdit-py-plugins-0.3.3.tar.gz", hash = "sha256:5cfd7e7ac582a594e23ba6546a2f406e94e42eb33ae596d0734781261c251260"},
+    {file = "mdit_py_plugins-0.3.3-py3-none-any.whl", hash = "sha256:36d08a29def19ec43acdcd8ba471d3ebab132e7879d442760d963f19913e04b9"},
 ]
 mdurl = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
@@ -3272,8 +3276,8 @@ nbclient = [
     {file = "nbclient-0.7.2.tar.gz", hash = "sha256:884a3f4a8c4fc24bb9302f263e0af47d97f0d01fe11ba714171b320c8ac09547"},
 ]
 nbconvert = [
-    {file = "nbconvert-7.2.5-py3-none-any.whl", hash = "sha256:3e90e108bb5637b5b8a1422af1156af1368b39dd25369ff7faa7dfdcdef18f81"},
-    {file = "nbconvert-7.2.5.tar.gz", hash = "sha256:8fdc44fd7d9424db7fdc6e1e834a02f6b8620ffb653767388be2f9eb16f84184"},
+    {file = "nbconvert-7.2.6-py3-none-any.whl", hash = "sha256:f933e82fe48b9a421e4252249f6c0a9a9940dc555642b4729f3f1f526bb16779"},
+    {file = "nbconvert-7.2.6.tar.gz", hash = "sha256:c9c0e4b26326f7658ebf4cda0acc591b9727c4e3ee3ede962f70c11833b71b40"},
 ]
 nbformat = [
     {file = "nbformat-5.7.0-py3-none-any.whl", hash = "sha256:1b05ec2c552c2f1adc745f4eddce1eac8ca9ffd59bb9fd859e827eaa031319f9"},
@@ -3505,32 +3509,31 @@ py = [
     {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
 ]
 pyarrow = [
-    {file = "pyarrow-9.0.0-cp310-cp310-macosx_10_13_universal2.whl", hash = "sha256:767cafb14278165ad539a2918c14c1b73cf20689747c21375c38e3fe62884902"},
-    {file = "pyarrow-9.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0238998dc692efcb4e41ae74738d7c1234723271ccf520bd8312dca07d49ef8d"},
-    {file = "pyarrow-9.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:55328348b9139c2b47450d512d716c2248fd58e2f04e2fc23a65e18726666d42"},
-    {file = "pyarrow-9.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fc856628acd8d281652c15b6268ec7f27ebcb015abbe99d9baad17f02adc51f1"},
-    {file = "pyarrow-9.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29eb3e086e2b26202f3a4678316b93cfb15d0e2ba20f3ec12db8fd9cc07cde63"},
-    {file = "pyarrow-9.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2e753f8fcf07d8e3a0efa0c8bd51fef5c90281ffd4c5637c08ce42cd0ac297de"},
-    {file = "pyarrow-9.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:3eef8a981f45d89de403e81fb83b8119c20824caddf1404274e41a5d66c73806"},
-    {file = "pyarrow-9.0.0-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:7fa56cbd415cef912677270b8e41baad70cde04c6d8a8336eeb2aba85aa93706"},
-    {file = "pyarrow-9.0.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:f8c46bde1030d704e2796182286d1c56846552c50a39ad5bf5a20c0d8159fc35"},
-    {file = "pyarrow-9.0.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8ad430cee28ebc4d6661fc7315747c7a18ae2a74e67498dcb039e1c762a2fb67"},
-    {file = "pyarrow-9.0.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:81a60bb291a964f63b2717fb1b28f6615ffab7e8585322bfb8a6738e6b321282"},
-    {file = "pyarrow-9.0.0-cp37-cp37m-win_amd64.whl", hash = "sha256:9cef618159567d5f62040f2b79b1c7b38e3885f4ffad0ec97cd2d86f88b67cef"},
-    {file = "pyarrow-9.0.0-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:5526a3bfb404ff6d31d62ea582cf2466c7378a474a99ee04d1a9b05de5264541"},
-    {file = "pyarrow-9.0.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:da3e0f319509a5881867effd7024099fb06950a0768dad0d6873668bb88cfaba"},
-    {file = "pyarrow-9.0.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:2c715eca2092273dcccf6f08437371e04d112f9354245ba2fbe6c801879450b7"},
-    {file = "pyarrow-9.0.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f11a645a41ee531c3a5edda45dea07c42267f52571f818d388971d33fc7e2d4a"},
-    {file = "pyarrow-9.0.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a5b390bdcfb8c5b900ef543f911cdfec63e88524fafbcc15f83767202a4a2491"},
-    {file = "pyarrow-9.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:d9eb04db626fa24fdfb83c00f76679ca0d98728cdbaa0481b6402bf793a290c0"},
-    {file = "pyarrow-9.0.0-cp39-cp39-macosx_10_13_universal2.whl", hash = "sha256:4eebdab05afa23d5d5274b24c1cbeb1ba017d67c280f7d39fd8a8f18cbad2ec9"},
-    {file = "pyarrow-9.0.0-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:02b820ecd1da02012092c180447de449fc688d0c3f9ff8526ca301cdd60dacd0"},
-    {file = "pyarrow-9.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:92f3977e901db1ef5cba30d6cc1d7942b8d94b910c60f89013e8f7bb86a86eef"},
-    {file = "pyarrow-9.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f241bd488c2705df930eedfe304ada71191dcf67d6b98ceda0cc934fd2a8388e"},
-    {file = "pyarrow-9.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c5a073a930c632058461547e0bc572da1e724b17b6b9eb31a97da13f50cb6e0"},
-    {file = "pyarrow-9.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f59bcd5217a3ae1e17870792f82b2ff92df9f3862996e2c78e156c13e56ff62e"},
-    {file = "pyarrow-9.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:fe2ce795fa1d95e4e940fe5661c3c58aee7181c730f65ac5dd8794a77228de59"},
-    {file = "pyarrow-9.0.0.tar.gz", hash = "sha256:7fb02bebc13ab55573d1ae9bb5002a6d20ba767bf8569b52fce5301d42495ab7"},
+    {file = "pyarrow-10.0.1-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:e00174764a8b4e9d8d5909b6d19ee0c217a6cf0232c5682e31fdfbd5a9f0ae52"},
+    {file = "pyarrow-10.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6f7a7dbe2f7f65ac1d0bd3163f756deb478a9e9afc2269557ed75b1b25ab3610"},
+    {file = "pyarrow-10.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb627673cb98708ef00864e2e243f51ba7b4c1b9f07a1d821f98043eccd3f585"},
+    {file = "pyarrow-10.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba71e6fc348c92477586424566110d332f60d9a35cb85278f42e3473bc1373da"},
+    {file = "pyarrow-10.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:7b4ede715c004b6fc535de63ef79fa29740b4080639a5ff1ea9ca84e9282f349"},
+    {file = "pyarrow-10.0.1-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:e3fe5049d2e9ca661d8e43fab6ad5a4c571af12d20a57dffc392a014caebef65"},
+    {file = "pyarrow-10.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:254017ca43c45c5098b7f2a00e995e1f8346b0fb0be225f042838323bb55283c"},
+    {file = "pyarrow-10.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:70acca1ece4322705652f48db65145b5028f2c01c7e426c5d16a30ba5d739c24"},
+    {file = "pyarrow-10.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:abb57334f2c57979a49b7be2792c31c23430ca02d24becd0b511cbe7b6b08649"},
+    {file = "pyarrow-10.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:1765a18205eb1e02ccdedb66049b0ec148c2a0cb52ed1fb3aac322dfc086a6ee"},
+    {file = "pyarrow-10.0.1-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:61f4c37d82fe00d855d0ab522c685262bdeafd3fbcb5fe596fe15025fbc7341b"},
+    {file = "pyarrow-10.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e141a65705ac98fa52a9113fe574fdaf87fe0316cde2dffe6b94841d3c61544c"},
+    {file = "pyarrow-10.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf26f809926a9d74e02d76593026f0aaeac48a65b64f1bb17eed9964bfe7ae1a"},
+    {file = "pyarrow-10.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:443eb9409b0cf78df10ced326490e1a300205a458fbeb0767b6b31ab3ebae6b2"},
+    {file = "pyarrow-10.0.1-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:f2d00aa481becf57098e85d99e34a25dba5a9ade2f44eb0b7d80c80f2984fc03"},
+    {file = "pyarrow-10.0.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:b1fc226d28c7783b52a84d03a66573d5a22e63f8a24b841d5fc68caeed6784d4"},
+    {file = "pyarrow-10.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:efa59933b20183c1c13efc34bd91efc6b2997377c4c6ad9272da92d224e3beb1"},
+    {file = "pyarrow-10.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:668e00e3b19f183394388a687d29c443eb000fb3fe25599c9b4762a0afd37775"},
+    {file = "pyarrow-10.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:d1bc6e4d5d6f69e0861d5d7f6cf4d061cf1069cb9d490040129877acf16d4c2a"},
+    {file = "pyarrow-10.0.1-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:42ba7c5347ce665338f2bc64685d74855900200dac81a972d49fe127e8132f75"},
+    {file = "pyarrow-10.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b069602eb1fc09f1adec0a7bdd7897f4d25575611dfa43543c8b8a75d99d6874"},
+    {file = "pyarrow-10.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94fb4a0c12a2ac1ed8e7e2aa52aade833772cf2d3de9dde685401b22cec30002"},
+    {file = "pyarrow-10.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db0c5986bf0808927f49640582d2032a07aa49828f14e51f362075f03747d198"},
+    {file = "pyarrow-10.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:0ec7587d759153f452d5263dbc8b1af318c4609b607be2bd5127dcda6708cdb1"},
+    {file = "pyarrow-10.0.1.tar.gz", hash = "sha256:1a14f57a5f472ce8234f2964cd5184cccaa8df7e04568c64edc33b23eb285dd5"},
 ]
 pycparser = [
     {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
@@ -3579,8 +3582,8 @@ pygments = [
     {file = "Pygments-2.13.0.tar.gz", hash = "sha256:56a8508ae95f98e2b9bdf93a6be5ae3f7d8af858b43e02c5a2ff083726be40c1"},
 ]
 pylint = [
-    {file = "pylint-2.15.7-py3-none-any.whl", hash = "sha256:1d561d1d3e8be9dd880edc685162fbdaa0409c88b9b7400873c0cf345602e326"},
-    {file = "pylint-2.15.7.tar.gz", hash = "sha256:91e4776dbcb4b4d921a3e4b6fec669551107ba11f29d9199154a01622e460a57"},
+    {file = "pylint-2.15.8-py3-none-any.whl", hash = "sha256:ea82cd6a1e11062dc86d555d07c021b0fb65afe39becbe6fe692efd6c4a67443"},
+    {file = "pylint-2.15.8.tar.gz", hash = "sha256:ec4a87c33da054ab86a6c79afa6771dc8765cb5631620053e727fcf3ef8cbed7"},
 ]
 pyparsing = [
     {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
@@ -3901,8 +3904,8 @@ tabulate = [
     {file = "tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c"},
 ]
 terminado = [
-    {file = "terminado-0.17.0-py3-none-any.whl", hash = "sha256:bf6fe52accd06d0661d7611cc73202121ec6ee51e46d8185d489ac074ca457c2"},
-    {file = "terminado-0.17.0.tar.gz", hash = "sha256:520feaa3aeab8ad64a69ca779be54be9234edb2d0d6567e76c93c2c9a4e6e43f"},
+    {file = "terminado-0.17.1-py3-none-any.whl", hash = "sha256:8650d44334eba354dd591129ca3124a6ba42c3d5b70df5051b6921d506fdaeae"},
+    {file = "terminado-0.17.1.tar.gz", hash = "sha256:6ccbbcd3a4f8a25a5ec04991f39a0b8db52dfcd487ea0e578d977e6752380333"},
 ]
 tinycss2 = [
     {file = "tinycss2-1.2.1-py3-none-any.whl", hash = "sha256:2b80a96d41e7c3914b8cda8bc7f705a4d9c49275616e886103dd839dfc847847"},
@@ -3950,8 +3953,8 @@ urllib3 = [
     {file = "urllib3-1.26.13.tar.gz", hash = "sha256:c083dd0dce68dbfbe1129d5271cb90f9447dea7d52097c6e0126120c521ddea8"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.17.0-py3-none-any.whl", hash = "sha256:40a7e06a98728fd5769e1af6fd1a706005b4bb7e16176a272ed4292473180389"},
-    {file = "virtualenv-20.17.0.tar.gz", hash = "sha256:7d6a8d55b2f73b617f684ee40fd85740f062e1f2e379412cb1879c7136f05902"},
+    {file = "virtualenv-20.17.1-py3-none-any.whl", hash = "sha256:ce3b1684d6e1a20a3e5ed36795a97dfc6af29bc3970ca8dab93e11ac6094b3c4"},
+    {file = "virtualenv-20.17.1.tar.gz", hash = "sha256:f8b927684efc6f1cc206c9db297a570ab9ad0e51c16fa9e45487d36d1905c058"},
 ]
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,11 @@ include = ['scistag/data/scistag_essentials.zip',
     'scistag/data/addon_packages.json']
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.2.2"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.dependencies]
-python = ">=3.9 <=3.10"
+python = ">=3.9 <3.12"
 matplotlib = "^3.5.2"
 requests = "^2.27.1"
 pandas = "^1.4.2"
@@ -25,7 +25,7 @@ pretty-html-table = { version = "^0.9.16", optional = true }
 Markdown = { version = "^3.4.1", optional = true }
 tabulate = { version = "^0.9.0", optional = true }
 filetype = { version = "^1.1.0", optional = true }
-pyarrow = { version = "^9.0.0", optional = true }
+pyarrow = { version = "^10.0.1", optional = true }
 Jinja2 = { version = "^3.1.2", optional = true }
 CairoSVG = { version = "^2.5.2", optional = true }
 opencv-contrib-python = { version = "^4.5.4.60", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ skip_empty = true
 # Regexes for lines to exclude from consideration
 exclude_lines = ["pragma: no cover",
     "def __repr__",
+    "pass",
     "if self.debug",
     "if not _UNIT_TESTING:",
     "if TYPE_CHECKING:",

--- a/scistag/common/dict_helper.py
+++ b/scistag/common/dict_helper.py
@@ -29,6 +29,18 @@ def dict_to_bullet_list(cd: dict | list,
             else:
                 cur_str += f"{tabs}* {bold_str}{key}{bold_str}: {value}\n"
     elif isinstance(cd, list):
+        flat = False
+        if len(cd) <= 4:
+            flat = True
+            for element in cd:
+                if element is not None and not isinstance(element,
+                                                          (float, bool, int)):
+                    flat = False
+                    break
+        if flat:
+            elements = ", ".join([str(element) for element in cd])
+            cur_str += f"{tabs} {elements}"
+            return cur_str
         for element in cd:
             if isinstance(element, dict) or isinstance(element, list):
                 if isinstance(element, dict):
@@ -39,9 +51,9 @@ def dict_to_bullet_list(cd: dict | list,
                                                level=level + 1,
                                                bold=bold)
                 if isinstance(element, dict):
-                    cur_str += f"{tabs}* }}\n"
+                    cur_str += f"\n{tabs}* }}\n"
                 else:
-                    cur_str += f"{tabs}* ]\n"
+                    cur_str += f"{tabs} ]\n"
             else:
                 cur_str += f"{tabs}* " + str(element) + "\n"
     return cur_str

--- a/scistag/filestag/azure/azure_storage_file_sink.py
+++ b/scistag/filestag/azure/azure_storage_file_sink.py
@@ -233,7 +233,10 @@ class AzureStorageFileSink(FileSink):
                 container_client = service.get_container_client(
                     container_name)
             else:
-                service.delete_container(container_name)
+                try:
+                    service.delete_container(container_name)
+                except ResourceNotFoundError:  # deletion in progress already
+                    pass
                 import time
                 start_time = time.time()
                 sleep_time = 0.25

--- a/scistag/imagestag/canvas.py
+++ b/scistag/imagestag/canvas.py
@@ -13,6 +13,7 @@ import PIL.ImageFont
 import PIL.ImageDraw
 
 from .font import Font
+from .pixel_format import PixelFormatTypes
 from .text_alignment_definitions import (HTextAlignment,
                                          VTextAlignment,
                                          HTextAlignmentTypes,
@@ -51,12 +52,12 @@ class Canvas:
                  size: Size2DTypes = None,
                  target_image: Image = None,
                  default_color: ColorTypes = Colors.BLACK,
-                 image_format: "PixelFormat" = "RGB"):
+                 format: PixelFormatTypes = "RGB"):
         """
         :param size: The size in pixels (if a new image shall be created)
         :param target_image: An image into which the canvas shall paint
         :param default_color: The background fill color
-        :param image_format: The image format, currently only RGB, RGBA and G
+        :param format: The image format, currently only RGB, RGBA and G
         """
         default_color = default_color if isinstance(default_color, Color) \
             else Color(default_color)
@@ -98,9 +99,9 @@ class Canvas:
                 assert isinstance(self.target_image, PIL.Image.Image)
             else:
                 img_format = PixelFormat(
-                    image_format).to_pil()
+                    format).to_pil()
                 if format is None:
-                    raise NotImplemented(f"{image_format} not supported")
+                    raise NotImplemented(f"{format} not supported")
                 self.target_image = \
                     PIL.Image.new(img_format, (self.width, self.height),
                                   color=default_color.to_int_rgba())

--- a/scistag/imagestag/canvas.py
+++ b/scistag/imagestag/canvas.py
@@ -11,6 +11,7 @@ from typing import Literal
 import PIL.Image
 import PIL.ImageFont
 import PIL.ImageDraw
+import numpy as np
 
 from .font import Font
 from .pixel_format import PixelFormatTypes
@@ -52,12 +53,12 @@ class Canvas:
                  size: Size2DTypes = None,
                  target_image: Image = None,
                  default_color: ColorTypes = Colors.BLACK,
-                 format: PixelFormatTypes = "RGB"):
+                 pixel_format: PixelFormatTypes = "RGB"):
         """
         :param size: The size in pixels (if a new image shall be created)
         :param target_image: An image into which the canvas shall paint
         :param default_color: The background fill color
-        :param format: The image format, currently only RGB, RGBA and G
+        :param pixel_format: The image format, currently only RGB, RGBA and G
         """
         default_color = default_color if isinstance(default_color, Color) \
             else Color(default_color)
@@ -91,7 +92,7 @@ class Canvas:
         Buffer to backup and restore the current painting state such as
         offset and clipping bounding
         """
-        self.target_image: Image
+        self.target_image: PIL.Image
         "The image into which the canvas will paint"
         if self.framework == ImsFramework.PIL:
             if target_image is not None:
@@ -99,9 +100,9 @@ class Canvas:
                 assert isinstance(self.target_image, PIL.Image.Image)
             else:
                 img_format = PixelFormat(
-                    format).to_pil()
-                if format is None:
-                    raise NotImplemented(f"{format} not supported")
+                    pixel_format).to_pil()
+                if pixel_format is None:
+                    raise NotImplemented(f"{pixel_format} not supported")
                 self.target_image = \
                     PIL.Image.new(img_format, (self.width, self.height),
                                   color=default_color.to_int_rgba())
@@ -161,7 +162,7 @@ class Canvas:
         self.offset = (self.offset[0] + offset[0], self.offset[1] + offset[1])
         return self
 
-    def shift_position_by_offset(self, position: tuple | Pos2D) \
+    def transform(self, position: tuple | Pos2D) \
             -> tuple[float, float]:
         """
         Shifts given coordinates by this canvas' current drawing offset
@@ -172,6 +173,13 @@ class Canvas:
         if isinstance(position, Pos2D):
             return self.offset[0] + position.x, self.offset[1] + position.y
         return self.offset[0] + position[0], self.offset[1] + position[1]
+
+    @property
+    def transformations_applied(self) -> bool:
+        """
+        Returns if any transformations are applied to the canvas
+        """
+        return self.offset[0] != 0.0 or self.offset[1] != 0.0
 
     def clip(self, offset: (float, float), size: (float, float)) -> Canvas:
         """
@@ -270,7 +278,7 @@ class Canvas:
             if it contains an alpha channel
         :return: Self
         """
-        pos = self.shift_position_by_offset(Pos2D(pos).to_int_tuple())
+        pos = self.transform(Pos2D(pos).to_int_tuple())
         pos = (int(round(pos[0])), int(round(pos[1])))
         if self.framework == ImsFramework.PIL:
             pil_image: PIL.Image.Image = image.to_pil()
@@ -343,7 +351,7 @@ class Canvas:
             color = Color(color)
         if outline_color is not None and isinstance(outline_color, tuple):
             outline_color = Color(outline_color)
-        xy = self.shift_position_by_offset(pos)
+        xy = self.transform(pos)
         x2y2 = (xy[0] + size.width - 1.0, xy[1] + size.height - 1.0)
         self.image_draw.rectangle(xy=(xy, x2y2),
                                   fill=color.to_int_rgba()
@@ -415,6 +423,41 @@ class Canvas:
                 for cur_rect, cur_color in zip(rectangles, colors):
                     self.image_draw.rectangle(xy=cur_rect,
                                               fill=cur_color)
+        return self
+
+    def polygon(self,
+                coords: list[Pos2DTypes] | np.ndarray,
+                color: ColorTypes | None = None,
+                outline_color: ColorTypes | None = None,
+                outline_width: int = 1) -> Canvas:
+        """
+        Draws a rectangle onto the canvas
+
+        :param coords: A list of coordinates defining the polygons bounding
+        :param color: The inner color
+        :param outline_color: The outline color
+        :param outline_width: The outline's width
+        :return: Self
+        """
+        if self.framework != ImsFramework.PIL:
+            raise NotImplementedError
+        if isinstance(coords, np.ndarray):
+            coords = coords.astype(float).tolist()
+        if self.transformations_applied:
+            coords = [self.transform(coord) for coord in
+                      coords]
+        coords = np.array(coords).flatten().tolist()
+        pixel_format = PixelFormat.from_pil(self.target_image.mode)
+        if color is not None:
+            color = Color(color).to_format(pixel_format)
+        if outline_color is not None and isinstance(outline_color, tuple):
+            outline_color = Color(outline_color).to_format(pixel_format)
+        self.image_draw.polygon(xy=coords,
+                                fill=color
+                                if color is not None else None,
+                                outline=outline_color
+                                if outline_color is not None else None,
+                                width=outline_width)
         return self
 
     def text(self,
@@ -492,7 +535,7 @@ class Canvas:
                 pos.x = pos.x + text_size.width // 2 - row_widths[index] // 2
             elif h_align == HTextAlignment.RIGHT:
                 pos.x = pos.x + text_size.width - row_widths[index]
-            xy = self.shift_position_by_offset(pos)
+            xy = self.transform(pos)
             if _show_formatting:
                 self.rect(pos=xy, size=(row_widths[index],
                                         font.row_height), color=None,

--- a/scistag/imagestag/color.py
+++ b/scistag/imagestag/color.py
@@ -299,7 +299,7 @@ class Color:
         :return: The hue saturation and value as int tuple
         """
         h, s, v = self.to_hsv()
-        return int(round(h / 360.) * 255), int(round(s)), int(round(v))
+        return int(round(h / 360. * 255)), int(round(s*255)), int(round(v*255))
 
     def to_hex(self) -> str:
         """

--- a/scistag/imagestag/color.py
+++ b/scistag/imagestag/color.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
+
+import typing
 from typing import Union
 from dataclasses import dataclass
+
+if typing.TYPE_CHECKING:
+    from scistag.imagestag import PixelFormat
 
 ColorTypes = Union["Color", tuple[int, int, int], tuple[int, int, int, int],
                    tuple[float, float, float],
@@ -140,6 +145,41 @@ class Color:
         self._int_rgba = tuple(
             [int(round(element * 255.0)) for element in self._rgba])
 
+    _HSV_TO_RGB_MAP = {
+        0: lambda p, q, t, v: Color(v, t, p),
+        1: lambda p, q, t, v: Color(q, v, p),
+        2: lambda p, q, t, v: Color(p, v, t),
+        3: lambda p, q, t, v: Color(p, q, v),
+        4: lambda p, q, t, v: Color(t, p, v),
+        5: lambda p, q, t, v: Color(v, p, q)
+    }
+    """
+    Hash hap for converting HSV to RGB 
+    """
+
+    @classmethod
+    def from_hsv(cls, h: float, s: float, v: float) -> Color:
+        """
+        Creates a Color from hue, saturation and value (HSV)
+
+        :param h: The hue, so the degree on the "color circle" from 0 .. 360
+        :param s: The saturation in percent (0 .. 1.0)
+        :param v: The value in percent (0 .. 1.0)
+        :return: The Color (RGB) representation
+        """
+        h /= 360.0
+        if s == 0.0:
+            v *= 255
+            return Color(v, v, v)
+        i = int(h * 6.0)
+        f = (h * 6.0) - i
+        p, q, t = (int(255 * (v * (1. - s))),
+                   int(255 * (v * (1. - s * f))),
+                   int(255 * (v * (1. - s * (1. - f)))))
+        v *= 255
+        i %= 6
+        return cls._HSV_TO_RGB_MAP[i](p, q, t, v)
+
     def __setattr__(self, key, value):
         if key in {"r", "g", "b", "a", "_rgba", "_int_rgba"} and \
                 "_int_rgba" in self.__dict__:
@@ -167,24 +207,99 @@ class Color:
     def to_int_rgb(self) -> (int, int, int):
         """
         Returns the color as rgb int tuple (values from 0 .. 255)
+
         :return: The RGB values
         """
         return self._int_rgba[0:3]
 
     def to_rgba(self) -> (float, float, float, float):
         """
-        Returns the color as rgb tuple (values from 0.0 .. 1.0)
+        Returns the color as rgba tuple (values from 0.0 .. 1.0)
 
-        :return: The RGB values
+        :return: The RGBA values
         """
         return tuple(self._rgba)
 
     def to_int_rgba(self) -> (int, int, int, int):
         """
-        Returns the color as rgb int tuple (values from 0 .. 255)
-        :return: The RGB values
+        Returns the color as rgba int tuple (values from 0 .. 255)
+
+        :return: The RGBA values
         """
         return tuple(self._int_rgba)
+
+    def to_int_bgra(self) -> (int, int, int, int):
+        """
+        Returns the color as bgra int tuple (values from 0 .. 255)
+
+        :return: The BGRA values
+        """
+        return (self._int_rgba[2], self._int_rgba[1], self._int_rgba[0],
+                self._int_rgba[3])
+
+    def to_int_bgr(self) -> (int, int, int):
+        """
+        Returns the color as bgr int tuple (values from 0 .. 255)
+
+        :return: The BGR values
+        """
+        return self._int_rgba[2], self._int_rgba[1], self._int_rgba[0]
+
+    def to_gray(self) -> float:
+        """
+        Returns the color as int gray value (0..1.0)
+
+        :return: The gray value (0 .. 1.0)
+        """
+        return min(max(0.299 * self.r + 0.587 * self.g + 0.114 * self.b, 0.0),
+                   1.0)  # convert to gray and clip between 0.0 and 1.0
+
+    def to_int_gray(self) -> int:
+        """
+        Returns the color as int gray value (0..255)
+
+        :return: The gray value (0 .. 255)
+        """
+        gray = min(max(0.299 * self.r + 0.587 * self.g + 0.114 * self.b, 0.0),
+                   1.0)  # convert to gray and clip between 0.0 and 1.0
+        return int(round(gray * 255))
+
+    def to_hsv(self) -> (float, float, float):
+        """
+        Converts the RGB color components to hue, saturation and value
+
+        :return: Hue (0..360.0 degree), Saturation (0 .. 1.0), Value (0.. 1.0)
+        """
+        r, g, b = self.r, self.g, self.b
+        max_val = max(r, g, b)  # dominant color component
+        min_val = min(r, g, b)  # most undominant color component
+        val_range = max_val - min_val
+        hue = 0.0
+        if max_val == min_val:
+            pass
+        elif max_val == r:
+            hue = (60.0 * ((g - b) / val_range) + 360.0) % 360.0
+        elif max_val == g:
+            hue = (60.0 * ((b - r) / val_range) + 120.0) % 360.0
+        elif max_val == b:
+            hue = (60.0 * ((r - g) / val_range) + 240.0) % 360.0
+        if max_val == 0.0:
+            saturation = 0.0
+        else:
+            saturation = (val_range / max_val)
+        value = max_val
+        return hue, saturation, value
+
+    def to_int_hsv(self) -> (int, int, int):
+        """
+        Converts the color to an integer HSV representation.
+
+        We are using the PILLOW definition (0..255, 0..255, 0..255)
+
+        :return: The hue saturation and value as int tuple
+        """
+        h, s, v = self.to_hsv()
+        return int(round(h / 360.) * 255), int(round(s)), int(round(v))
 
     def to_hex(self) -> str:
         """
@@ -211,6 +326,25 @@ class Color:
                self.g != other.g or \
                self.b != other.b or \
                self.a != other.a
+
+    def to_format(self, pixel_format: "PixelFormat") -> tuple | int | float:
+        """
+        Returns the value as representation in the given target pixel format
+
+        :param pixel_format: The format to convert to
+        :return: The converted color
+        """
+        from scistag.imagestag import PixelFormat
+        _CONVERSION_METHODS = {
+            PixelFormat.RGB: lambda color: color.to_int_rgb(),
+            PixelFormat.RGBA: lambda color: color.to_int_rgba(),
+            PixelFormat.BGR: lambda color: color.to_int_bgr(),
+            PixelFormat.BGRA: lambda color: color.to_int_bgr(),
+            PixelFormat.GRAY: lambda color: color.to_int_gray(),
+            PixelFormat.HSV: lambda color: color.to_int_hsv()}
+        if pixel_format in _CONVERSION_METHODS:
+            return _CONVERSION_METHODS[pixel_format](self)
+        raise ValueError(f"Unsupported target format {pixel_format}")
 
 
 class Colors:

--- a/scistag/imagestag/definitions.py
+++ b/scistag/imagestag/definitions.py
@@ -62,7 +62,7 @@ class ImsFramework(enum.Enum):
 
     PIL = "PIL"
     "Prefer using a Pillow image handle to store the pixel data"
-    RAW = "NP"
+    RAW = "RAW"
     """
     Prefer using numpy to store the image data. RGB and RGBA images are 
     represented in RGB/RGBA order
@@ -72,6 +72,15 @@ class ImsFramework(enum.Enum):
     Prefer using OpenCV to store the pixel data. RGB and RGBA images are 
     represented in BGR/BGRA order
     """
+
+    @classmethod
+    def _missing_(cls, value: object) -> Any:
+        missing_dict = {"PIL": cls.PIL,
+                        "RAW": cls.RAW,
+                        "CV": cls.CV}
+        if value in missing_dict:
+            return missing_dict[value]
+        return None
 
 
 __all__ = ["ImsFramework", "get_opencv", "PIL_AVAILABLE", "PIL"]

--- a/scistag/imagestag/image.py
+++ b/scistag/imagestag/image.py
@@ -14,7 +14,7 @@ import numpy as np
 from .color import Color, Colors
 from .bounding import Bounding2DTypes, Bounding2D
 from .interpolation import InterpolationMethod
-from .pixel_format import PixelFormat
+from .pixel_format import PixelFormat, PixelFormatTypes
 from .size2d import Size2D, Size2DTypes
 from .definitions import ImsFramework, get_opencv
 from .image_base import ImageBase
@@ -59,7 +59,7 @@ class Image(ImageBase):
 
     def __init__(self, source: ImageSourceTypes | None = None,
                  framework: ImsFramework | Literal["PIL", "RAW", "CV"] = None,
-                 pixel_format: PixelFormat | None = None,
+                 pixel_format: PixelFormatTypes | None = None,
                  size: Size2DTypes | None = None,
                  bg_color: Color | None = None,
                  **params):
@@ -82,6 +82,8 @@ class Image(ImageBase):
 
         Raises a ValueError if the image could not be loaded
         """
+        if pixel_format is not None and isinstance(pixel_format, str):
+            pixel_format = PixelFormat(pixel_format)
         if size is not None:
             size = Size2D(size) if not isinstance(size, Size2D) else size
             if bg_color is None:

--- a/scistag/imagestag/image.py
+++ b/scistag/imagestag/image.py
@@ -93,7 +93,7 @@ class Image(ImageBase):
                 pixel_format = PixelFormat.RGB
             from .canvas import Canvas
             canvas = Canvas(size=size, default_color=bg_color,
-                            format=pixel_format)
+                            pixel_format=pixel_format)
             source = canvas.target_image
         if pixel_format is None:
             pixel_format = PixelFormat.RGB

--- a/scistag/imagestag/image.py
+++ b/scistag/imagestag/image.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import hashlib
 import io
 import os
-from typing import Union, TYPE_CHECKING, Any
+from typing import Union, TYPE_CHECKING, Any, Literal
 
 import PIL.Image
 import numpy as np
@@ -58,7 +58,7 @@ class Image(ImageBase):
     """
 
     def __init__(self, source: ImageSourceTypes | None = None,
-                 framework: ImsFramework = None,
+                 framework: ImsFramework | Literal["PIL", "RAW", "CV"] = None,
                  pixel_format: PixelFormat | None = None,
                  size: Size2DTypes | None = None,
                  bg_color: Color | None = None,
@@ -93,7 +93,7 @@ class Image(ImageBase):
                 pixel_format = PixelFormat.RGB
             from .canvas import Canvas
             canvas = Canvas(size=size, default_color=bg_color,
-                            image_format=pixel_format)
+                            format=pixel_format)
             source = canvas.target_image
         if pixel_format is None:
             pixel_format = PixelFormat.RGB
@@ -101,7 +101,7 @@ class Image(ImageBase):
         "The image's width in pixels"
         self.height = 1
         "The image's height in pixels"
-        self.framework = framework if framework is not None else \
+        self.framework = ImsFramework(framework) if framework is not None else \
             ImsFramework.PIL
         "The framework being used. ImsFramework.PIL by default."
         self._pil_handle: PIL.Image.Image | None = None
@@ -115,15 +115,15 @@ class Image(ImageBase):
             self._prepare_data_source(framework, source,
                                       self.pixel_format, **params)
         # ------------------------------------------
-        if framework is None:
-            framework = ImsFramework.PIL
-        if framework == ImsFramework.PIL:
+        if self.framework is None:
+            self.framework = ImsFramework.PIL
+        if self.framework == ImsFramework.PIL:
             self._init_as_pil(source)
-        elif framework == ImsFramework.RAW:
+        elif self.framework == ImsFramework.RAW:
             self._pixel_data = self._pixel_data_from_source(source)
             self.height, self.width = self._pixel_data.shape[0:2]
             self.pixel_format = self.detect_format(self._pixel_data)
-        elif framework == ImsFramework.CV:
+        elif self.framework == ImsFramework.CV:
             self._init_as_cv2(source)
         else:
             raise NotImplementedError

--- a/scistag/imagestag/image_filter.py
+++ b/scistag/imagestag/image_filter.py
@@ -72,7 +72,7 @@ class ImageFilter:
             input_image = {
                 IMAGE_FILTER_IMAGE: Image(input_image,
                                           framework=ImsFramework.RAW)}
-        # convert format if the filter requires a special format
+        # convert pixel_format if the filter requires a special pixel_format
         if self.required_format is not None:
             is_gray = input_image[
                           IMAGE_FILTER_IMAGE].pixel_format != PixelFormat.GRAY
@@ -91,7 +91,7 @@ class ImageFilter:
         # execute filter
         result = self._apply_filter(input_image)
         result[IMAGE_FILTER_NAME] = self.name
-        # convert to original input format
+        # convert to original input pixel_format
         if isinstance(original_input,
                       dict):  # if a dictionary was passed in return all details
             return result

--- a/scistag/imagestag/pixel_format.py
+++ b/scistag/imagestag/pixel_format.py
@@ -6,7 +6,7 @@ formats supported by an :class:`Image` and it's properties.
 from __future__ import annotations
 
 from enum import IntEnum
-from typing import Any, Literal
+from typing import Any, Literal, Union
 
 from numpy import uint8
 
@@ -177,3 +177,11 @@ class PixelFormat(IntEnum):
             }
 
         return Definitions.bands[self]
+
+
+PixelFormatTypes = Union[
+    PixelFormat, Literal["RGB", "RGBA", "BGR", "BGRA", "HSV", "G", "GRAY"]]
+"""
+Definition of supported ways to define a pixel format, either as string or
+as PixelFormat"
+"""

--- a/scistag/plotstag/plot.py
+++ b/scistag/plotstag/plot.py
@@ -201,7 +201,7 @@ class Plot:
                 first_layer = self.layers[0]
                 canvas_size = first_layer.size.to_int_tuple()
                 image = canvas.to_image()
-                off = canvas.shift_position_by_offset(layer_offset)
+                off = canvas.transform(layer_offset)
                 image = image.cropped(box=(off[0],
                                            off[1],
                                            off[0] + canvas_size[0],

--- a/scistag/tests/filestag4azure/test_azure_storage_file_sink.py
+++ b/scistag/tests/filestag4azure/test_azure_storage_file_sink.py
@@ -160,14 +160,15 @@ def test_azure_file_sink_deletion():
     """
     # ensure container exists
     AzureStorageFileSink(sink_target_container_string)
+    AzureStorageFileSink(sink_target_container_string + "x")
+    AzureStorageFileSink(sink_target_container_string + "empty")
     # test recreation
     with pytest.raises(ValueError):  # deletion requires some time
-        AzureStorageFileSink(sink_target_container_string,
+        AzureStorageFileSink(sink_target_container_string + "x",
                              recreate_container=True,
-                             delete_timeout_s=0.5)
-    sink = AzureStorageFileSink(sink_target_container_string,
-                                recreate_container=True)
-    source = FileSource.from_source(sink_target_container_string,
+                             delete_timeout_s=0.1)
+    sink = AzureStorageFileSink(sink_target_container_string)
+    source = FileSource.from_source(sink_target_container_string + "empty",
                                     fetch_file_list=True)
     assert len(source.file_list) == 0
     # upload new data
@@ -177,4 +178,4 @@ def test_azure_file_sink_deletion():
     time.sleep(1.0)
     source = FileSource.from_source(sink_target_container_string,
                                     fetch_file_list=True)
-    assert len(source.file_list) == 1
+    assert len(source.file_list) >= 1

--- a/scistag/tests/imagestag/test_canvas.py
+++ b/scistag/tests/imagestag/test_canvas.py
@@ -1,10 +1,11 @@
 """
 Tests the :class:`Canvas` class.
 """
+import numpy as np
 import pytest
 
 from scistag.tests.visual_test_log_scistag import VisualTestLogSciStag
-from scistag.imagestag import Colors, Color
+from scistag.imagestag import Colors, Color, Size2D
 from scistag.imagestag.canvas import Canvas
 
 from . import vl, skip_imagestag
@@ -119,3 +120,93 @@ def test_draw_rectangle_list():
         hash_val = "b2ca8a2a847d9ffc4092476124e74b5d" if outline \
             else "0eb9e0c61ed35d0aabb35cf713500e58"
         vl.test.assert_image("draw_rectangle", canvas, hash_val)
+
+
+@pytest.mark.skipif(skip_imagestag, reason="ImageStag tests disabled")
+def test_draw_polygon_fill():
+    """
+    Filled polygon
+    """
+    vl.sub_test("Rendering polygons")
+    canvas = Canvas(size=(128, 128), default_color=Colors.BLACK)
+    polygon = [(20, 20), (80, 30), (90, 90), (30, 100)]
+    canvas.polygon(polygon, color=Colors.RED)
+    hash_val = "3f90539daefb6b3dc60fa8129c1c6377"
+    vl.test.assert_image("polygon_convex_fill", canvas, hash_val)
+
+
+@pytest.mark.skipif(skip_imagestag, reason="ImageStag tests disabled")
+def test_draw_polygon_fill_outline():
+    """
+    Filled polygon with outline
+    """
+    canvas = Canvas(size=(128, 128), default_color=Colors.BLACK)
+    polygon = [(20, 20), (80, 30), (90, 90), (30, 100)]
+    canvas.polygon(polygon, color=Colors.RED, outline_color=Colors.BLUE,
+                   outline_width=2)
+    hash_val = "6af0b5c529594912d9fbae60e1d7bab9"
+    vl.test.assert_image("polygon_convex_fill_border", canvas, hash_val)
+
+
+@pytest.mark.skipif(skip_imagestag, reason="ImageStag tests disabled")
+def test_draw_polygon_fill_outline_concave():
+    """
+    Concave filled polygon with outline
+    """
+    canvas = Canvas(size=(128, 128), default_color=Colors.BLACK)
+    canvas.add_offset_shift((15, 15))
+    polygon = np.array([(20, 20), (80, 30), (90, 90), (60, 70), (30, 100)])
+    canvas.polygon(polygon, color=Colors.RED, outline_color=Colors.WHITE,
+                   outline_width=8)
+    hash_val = "7b68caffba93580e75f3079dd0e959bf"
+    vl.test.assert_image("polygon_convex_fill_border_concave", canvas, hash_val)
+
+
+@pytest.mark.skipif(skip_imagestag, reason="ImageStag tests disabled")
+def test_draw_lines():
+    """
+    Lines and multi-lines
+    """
+    canvas = Canvas(size=(128, 128), default_color=Colors.BLACK)
+    line_list = [(20, 20), (80, 30), (90, 90), (60, 70), (30, 100)]
+    canvas.line(line_list, color=Colors.RED, width=3)
+    hash_val = "69cc3fab0cbaef77fae888186050fb66"
+    vl.test.assert_image("line_list", canvas, hash_val)
+    # shift line with two points
+    canvas.add_offset_shift((15, 15))
+    canvas = Canvas(size=(128, 128), default_color=Colors.BLACK)
+    line_list = [(20, 20), (80, 30)]
+    canvas.line(line_list, color=Colors.RED, width=10, curved_joints=True)
+    hash_val = "83e521e68b400fae3f2c476728aecb8e"
+    vl.test.assert_image("line_list_two_points", canvas, hash_val)
+    # shift line with three points and joint
+    canvas = Canvas(size=(128, 128), default_color=Colors.BLACK)
+    canvas.add_offset_shift((15, 15))
+    line_list = np.array([(20, 20), (80, 30), (100, 80)])
+    canvas.line(line_list, color=Colors.RED, width=10, curved_joints=True)
+    hash_val = "a1ebba1a8b202b07f7b4a039b384df17"
+    vl.test.assert_image("line_list_three_points", canvas, hash_val)
+
+
+@pytest.mark.skipif(skip_imagestag, reason="ImageStag tests disabled")
+def test_draw_circles():
+    """
+    Circles
+    """
+    canvas = Canvas(size=(128, 128), default_color=Colors.BLACK)
+    canvas.circle((70, 70), radius=30, color=Colors.RED)
+    hash_val = "dbcc979c2e855e1b0f5efde1d394dfbb"
+    vl.test.assert_image("circle", canvas, hash_val)
+    # shifted and as ellipse
+    canvas.add_offset_shift((15, 15))
+    canvas = Canvas(size=(128, 128), default_color=Colors.BLACK)
+    canvas.circle((70, 70), radius=(40, 20), color=Colors.RED)
+    hash_val = "81dc4f4c659a9c4867f413470a8f299f"
+    vl.test.assert_image("ellipse", canvas, hash_val)
+    # with outline
+    canvas = Canvas(size=(128, 128), default_color=Colors.BLACK)
+    canvas.add_offset_shift((15, 15))
+    canvas.circle((70, 70), size=Size2D(80, 40), outline_color=Colors.BLUE,
+                  outline_width=3)
+    hash_val = "751338bf0aeebf031e19c2cf7eba0a2e"
+    vl.test.assert_image("ellipse_outline", canvas, hash_val)

--- a/scistag/tests/imagestag/test_color.py
+++ b/scistag/tests/imagestag/test_color.py
@@ -51,3 +51,21 @@ def test_color_basics():
     # test passing colors as rgb int
     assert Color(255, 255, 255) == Color((255, 255, 255))
     assert Color(255, 255, 255, 127 / 255) == Color(255, 255, 255, 127)
+
+
+def test_conversion_functions():
+    """
+    Test advanced conversion functions
+    """
+    assert Color(244, 48, 29).to_int_hsv() == (4, 225, 244)
+    h, s, v = Color(30, 98, 29).to_hsv()
+    assert h == pytest.approx(119, 0.01)
+    assert s == pytest.approx(0.7, 0.01)
+    assert v == pytest.approx(0.3843, 0.01)
+    gray = Color(123, 64, 59).to_gray()
+    assert gray == pytest.approx(0.3179, 0.01)
+    gray = Color(30, 190, 110).to_int_gray()
+    assert gray == pytest.approx(133, 0.01)
+    assert Color(255, 44, 38).to_int_bgr() == (38, 44, 255)
+    assert Color(255, 44, 38).to_int_bgra() == (38, 44, 255, 255)
+    assert Color(255, 44, 38, 33).to_int_bgra() == (38, 44, 255, 33)

--- a/scistag/tests/imagestag/test_image.py
+++ b/scistag/tests/imagestag/test_image.py
@@ -254,7 +254,7 @@ def test_creation():
     assert tuple(image.get_pixels()[0, 0]) == (255, 0, 0)
     with pytest.raises(ValueError):
         Image(source=np.zeros((5, 5)), size=(5, 5))
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(ValueError):
         Image(source=np.zeros((5, 5), dtype=np.uint8), framework=99)
 
     from_web = Image(TestConstants.STAG_URL, cache=True)

--- a/scistag/tests/vislog/test_auto_reloader.py
+++ b/scistag/tests/vislog/test_auto_reloader.py
@@ -77,7 +77,7 @@ def test_auto_reload():
         content = test_client.get("/index")
         assert content.text is not None
         assert "testlog" in content.text
-        assert VisualLogAutoReloader.reload_count == 2
+        assert VisualLogAutoReloader.reload_count >= 2
         assert VisualLogAutoReloader.error_count >= 1
     VisualLogAutoReloader.testing = False
     VisualLogAutoReloader.reset()

--- a/scistag/tests/vislog/test_dict_list.py
+++ b/scistag/tests/vislog/test_dict_list.py
@@ -14,7 +14,7 @@ def test_list():
         [1, 2, 3, "a", 123.4,
          ["A", "B", "C", {"adict": {"withADict": {"value": 123}}}]])
     vl.add([4, 5, 6])
-    vl.test.assert_cp_diff('e7a636f66ba4f77a536641bee7bc17f1')
+    vl.test.assert_cp_diff('1e71f6376cd72e1f5c7bc52199f66d1f')
 
 
 def test_dict():
@@ -30,7 +30,7 @@ def test_dict():
                 "orderIds": [1234, 5678]
                 }
     vl.log_dict(new_dict)
-    vl.test.assert_cp_diff("d7a84ee5a7e175a1cf9d6205c284e48c")
+    vl.test.assert_cp_diff('0c1ae1ab8ae88aba31308d4837b51156')
     vl.test.checkpoint("vislog.dict_add")
     vl.add(new_dict)
-    vl.test.assert_cp_diff("d7a84ee5a7e175a1cf9d6205c284e48c")
+    vl.test.assert_cp_diff("0c1ae1ab8ae88aba31308d4837b51156")

--- a/scistag/tests/vislog/test_image_logger.py
+++ b/scistag/tests/vislog/test_image_logger.py
@@ -56,6 +56,7 @@ def test_image():
     vl.sub_test("Logging an image provided as byte stream")
     vl.test.checkpoint("image.log.bytestream")
     vl.image(image_data.encode(), alt_text="image from byte stream")
+    vl.add(image_data.encode())
     # insert image from web (as url)
     vl.image(TestConstants.STAG_URL, alt_text="Image link from URL",
              download=False,

--- a/scistag/tests/vislog/test_log_tables.py
+++ b/scistag/tests/vislog/test_log_tables.py
@@ -1,6 +1,9 @@
 """
 Tests the table logging helper class VisualTableLogger
 """
+import sys
+
+import pytest
 
 from . import vl
 
@@ -23,3 +26,56 @@ def test_basics_logging_methods():
     table.add_row(["1", 2, 3.0])
     table.close()
     vl.test.assert_cp_diff(hash_val="ab5f470aa9025c4dd4158c9908013662")
+
+
+def test_table_enumeration():
+    """
+    Test the basic table logging methods
+    """
+    vl.test.begin("Table logging via enumeration")
+
+    with pytest.raises(ValueError):
+        with vl.table.begin() as table:
+            table.__enter__()
+            for _ in table:
+                pass
+    table.__exit__(*sys.exc_info())
+
+    with pytest.raises(ValueError):
+        with vl.table.begin(size=(3, None)) as table:
+            for _ in table:
+                pass
+    with pytest.raises(ValueError):
+        with vl.table.begin(size=(None, 3)) as table:
+            for row in table:
+                for _ in row:
+                    pass
+    vl.test.checkpoint("log.table.iter")
+
+    for row_index, row in enumerate(vl.table.begin(size=(4, 3))):
+        for col_index, col in enumerate(row):
+            vl.log(f"{col_index}x{row_index}")
+    vl.test.assert_cp_diff(hash_val="5786dc109acba9d6672228977fca17ac")
+    vl.test.checkpoint("log.table.iter_pass_size")
+    for row_index, row in enumerate(vl.table.begin().iter_rows(3)):
+        for col_index, col in enumerate(row.iter_cols(4)):
+            vl.log(f"{col_index}x{row_index}")
+    vl.test.assert_cp_diff(hash_val="5786dc109acba9d6672228977fca17ac")
+
+
+def test_table_creation():
+    """
+    Tests the logging of table with provided data
+    """
+    vl.test.begin("Table logging direct")
+    vl.test.checkpoint("log.table.direct")
+    vl.table.show([[1, 2, 3], [4, 5, 6]], index=True)
+    vl.test.assert_cp_diff(hash_val="6906d0ec9825898922bb7c577ef8aa37")
+
+    vl.test.checkpoint("log.table.add_col")
+    for row_index, row in enumerate(vl.table.begin().iter_rows(3)):
+        row.add_col("123")
+        row.add_col("456")
+        row.add_col(lambda: vl.log.info("789"))
+        row.add_col("**Markdown**", md=True)
+    vl.test.assert_cp_diff(hash_val="9cf7177b040fa15e054bb5dc7f2266de")

--- a/scistag/tests/vislog/test_visual_log_basics.py
+++ b/scistag/tests/vislog/test_visual_log_basics.py
@@ -12,6 +12,7 @@ import scistag.common
 from . import vl
 from ...emojistag import render_emoji
 from ...filestag import FilePath, FileStag
+from ...imagestag import Color
 from ...logstag import LogLevel
 from ...logstag.console_stag import Console
 from ...vislog import VisualLog
@@ -53,6 +54,13 @@ def test_basics_logging_methods():
     vl.page_break()
     vl.test.assert_cp_diff(hash_val='deb09ddaa3e0f23720a6536af11da0c9')
     assert not vl.target_log.is_micro
+
+
+def test_add_and_links():
+    """
+    Tests the add and link functionalities
+    :return:
+    """
     vl.test.checkpoint("log.link")
     vl.link("SciStag", "https://github.com/scistag/scistag")
     vl.add("Test text")
@@ -60,7 +68,14 @@ def test_basics_logging_methods():
     vl.add(123.456)
     vl.add([123, 456])
     vl.add({"someProp": "someVal"})
-    vl.test.assert_cp_diff(hash_val='e2c7f27c770c8cbe5abfdeaf6b78ab19')
+    with pytest.raises(ValueError):
+        vl.add(Color(22, 33, 44))
+    with pytest.raises(ValueError):
+        vl.add(b"12345")
+    vl.test.assert_cp_diff(hash_val='dbee28561898b78b5ddc19ca55b18878')
+    vl.test.checkpoint("log.link_adv")
+    vl.link("Multiline\nLink", "https://github.com/scistag/scistag")
+    vl.test.assert_cp_diff(hash_val='9ebcc1aada224b97a34d223ae5da4875')
     assert vl.max_fig_size.width > 100
 
 
@@ -345,6 +360,19 @@ def test_printing():
     log.render()
 
 
+def test_backup():
+    """
+    Tests creating and inserting backups
+    """
+    other_log = VisualLog()
+    other_log.default_builder.log("Hello World")
+    backup = other_log.default_builder.create_backup()
+    vl.sub_test("inserting backups")
+    vl.test.checkpoint("log.title")
+    vl.insert_backup(backup)
+    vl.test.assert_cp_diff(hash_val="ce44db53fa376147f10abb4f5967a152")
+
+
 def test_start_browser():
     """
     Tests the browser startup
@@ -352,7 +380,8 @@ def test_start_browser():
     with mock.patch("webbrowser.open") as open_browser:
         vis_log = VisualLog(start_browser=True, refresh_time_s=0.05)
         vis_log.run_server(test=True, show_urls=False)
-        vis_log._start_app_or_browser(real_log=vis_log, url=vis_log.local_live_url)
+        vis_log._start_app_or_browser(real_log=vis_log,
+                                      url=vis_log.local_live_url)
         assert open_browser.called
     if scistag.common.SystemInfo.os_type.is_windows or os.environ.get(
             "QT_TESTS", "0") == "1":
@@ -360,3 +389,10 @@ def test_start_browser():
             vis_log = VisualLog(app="cute", refresh_time_s=0.05)
             vis_log.run_server(test=True, show_urls=False)
             assert not open_browser.called
+
+
+def test_dependencies():
+    """
+    Tests dependency handling
+    """
+    vl.add_file_dependency("test.md")  # not yet implemented

--- a/scistag/tests/vislog/test_visual_log_basics.py
+++ b/scistag/tests/vislog/test_visual_log_basics.py
@@ -60,7 +60,7 @@ def test_basics_logging_methods():
     vl.add(123.456)
     vl.add([123, 456])
     vl.add({"someProp": "someVal"})
-    vl.test.assert_cp_diff(hash_val='1041304ae2e7d328eca4e0f06f4ba8a6')
+    vl.test.assert_cp_diff(hash_val='e2c7f27c770c8cbe5abfdeaf6b78ab19')
     assert vl.max_fig_size.width > 100
 
 
@@ -354,7 +354,8 @@ def test_start_browser():
         vis_log.run_server(test=True, show_urls=False)
         vis_log._start_app_or_browser(real_log=vis_log, https=False)
         assert open_browser.called
-    if scistag.common.SystemInfo.os_type.is_windows:
+    if scistag.common.SystemInfo.os_type.is_windows or os.environ.get(
+            "QT_TESTS", "0") == "1":
         with mock.patch("webbrowser.open") as open_browser:
             vis_log = VisualLog(app="cute", refresh_time_s=0.05)
             vis_log.run_server(test=True, show_urls=False)

--- a/scistag/tests/vislog/test_visual_log_basics.py
+++ b/scistag/tests/vislog/test_visual_log_basics.py
@@ -352,7 +352,7 @@ def test_start_browser():
     with mock.patch("webbrowser.open") as open_browser:
         vis_log = VisualLog(start_browser=True, refresh_time_s=0.05)
         vis_log.run_server(test=True, show_urls=False)
-        vis_log._start_app_or_browser(real_log=vis_log, https=False)
+        vis_log._start_app_or_browser(real_log=vis_log, url=vis_log.local_live_url)
         assert open_browser.called
     if scistag.common.SystemInfo.os_type.is_windows or os.environ.get(
             "QT_TESTS", "0") == "1":

--- a/scistag/vislog/__init__.py
+++ b/scistag/vislog/__init__.py
@@ -5,9 +5,10 @@ Integrates VisualLog and VisualTestLog
 from .visual_log import VisualLog
 
 from .visual_test_log import VisualTestLog
-from .visual_log_builder import VisualLogBuilder
+from .visual_log_builder import VisualLogBuilder, VisualLogBackup
 from .visual_log_builder_extension import VisualLogBuilderExtension
 from .visual_log_statistics import VisualLogStatistics
 
 __all__ = ["VisualLog", "VisualTestLog", "VisualLogBuilder",
-           "VisualLogStatistics", "VisualLogBuilderExtension"]
+           "VisualLogBackup", "VisualLogStatistics",
+           "VisualLogBuilderExtension"]

--- a/scistag/vislog/css/visual_log.css
+++ b/scistag/vislog/css/visual_log.css
@@ -78,12 +78,31 @@ table.log_table td, table.log_table th {
 }
 
 .greenButton {
-  background-color: #4CAF50; /* Green */
-  border: none;
-  color: white;
-  padding: 15px 32px;
-  text-align: center;
-  text-decoration: none;
-  display: inline-block;
-  font-size: 16px;
+    background-color: #4CAF50; /* Green */
+    border: none;
+    color: white;
+    padding: 15px 32px;
+    text-align: center;
+    text-decoration: none;
+    display: inline-block;
+    font-size: 16px;
+}
+
+a:link {
+    text-decoration: none;
+    color: darkblue;
+}
+
+a:visited {
+    text-decoration: none;
+    color: darkblue;
+}
+
+a:hover {
+    color: #5050FF;
+    text-decoration: underline;
+}
+
+a:active {
+    text-decoration: underline;
 }

--- a/scistag/vislog/templates/base_footer.html
+++ b/scistag/vislog/templates/base_footer.html
@@ -1,1 +1,3 @@
+<br>
+<p align="center"><small>Built with <a href="https://github.com/scistag/scistag">SciStag</a></small></p>
 </body></html>

--- a/scistag/vislog/visual_image_logger.py
+++ b/scistag/vislog/visual_image_logger.py
@@ -40,6 +40,7 @@ class VisualImageLogger:
                  download: bool = False,
                  scaling: float = 1.0,
                  max_width: int | float | None = None,
+                 format: str | tuple[str, int] | None = None,
                  optical_scaling: float = 1.0,
                  html_linebreak=True):
         """
@@ -62,6 +63,10 @@ class VisualImageLogger:
             - float = Scale the image to the defined percentual size of the
                 max_fig_size, 1.0 = max_fig_size
 
+        :param format: The image format, with our without quality grade
+            e.g. "jpg" or ("jpg", 90).
+
+            Has no effect if the image was already as bytes stream.
         :param optical_scaling: Defines the factor with which the image shall
             be visualized on the html page without really rescaling the image
             itself and thus giving the possibility to zoom in the browser.
@@ -115,9 +120,15 @@ class VisualImageLogger:
         if isinstance(source, bytes):
             encoded_image = source
         else:
+            img_format, quality = self.log.image_format, self.log.image_quality
+            if format is not None:
+                if isinstance(format, tuple):
+                    img_format, quality = format
+                else:
+                    img_format = format
             encoded_image = source.encode(
-                filetype=self.log.image_format,
-                quality=self.log.image_quality)
+                filetype=img_format,
+                quality=quality)
         # store on disk if required
         if self.log.log_to_disk:
             file_location = self._log_image_to_disk(filename, name, source,

--- a/scistag/vislog/visual_log_autoreloader.py
+++ b/scistag/vislog/visual_log_autoreloader.py
@@ -217,8 +217,7 @@ class VisualLogAutoReloader:
         try:
             print(f"Auto-reloading enabled for module {cls.imp_module}")
             cls._embedded_log._start_app_or_browser(real_log=cls.main_log,
-                                                    https=False,
-                                                    url_prefix=url_prefix)
+                                                    url=cls.main_log.local_live_url)
             while True:
                 with cls._access_lock:
                     sht = cls._shall_terminate

--- a/scistag/vislog/visual_log_background_handler.py
+++ b/scistag/vislog/visual_log_background_handler.py
@@ -1,0 +1,25 @@
+"""
+:class:`VisualLogBackgroundHandler` runs the execution logic of a VisualLog
+based application in a background thread so a UI application such as Qt may
+use the main thread.
+"""
+
+from scistag.common.mt import ManagedThread
+from scistag.vislog import VisualLog
+
+
+class VisualLogBackgroundHandler(ManagedThread):
+    """
+    Executes the updating logic of a VisualLog app in the background
+    """
+
+    def __init__(self, log: VisualLog):
+        """
+        :param log: The log to update in the background thread
+        """
+        super().__init__("vislogbgthread")
+        self.log = log
+
+    def run_loop(self):
+        self.log._run_log_mt(True, True, wait=True)
+        self.terminate()

--- a/scistag/vislog/visual_log_builder.py
+++ b/scistag/vislog/visual_log_builder.py
@@ -198,9 +198,9 @@ class VisualLogBuilder:
             except TypeError:
                 raise ValueError(f"Data type could not be detected")
             from scistag.imagestag.image import SUPPORTED_IMAGE_FILETYPES
-            if ft.extension in SUPPORTED_IMAGE_FILETYPES:
+            if ft is not None and ft.extension in SUPPORTED_IMAGE_FILETYPES:
                 self.image(content)
-                return
+                return self
             else:
                 raise ValueError(f"Data of filetype {ft} not supported")
         # image
@@ -229,7 +229,7 @@ class VisualLogBuilder:
             return self
         self.log(str(content))
         if content is None or not isinstance(content, bytes):
-            raise NotImplementedError("Data type not supported")
+            raise ValueError("Data type not supported")
         return self
 
     def title(self, text: str) -> VisualLogBuilder:
@@ -450,7 +450,8 @@ class VisualLogBuilder:
                         build_table(df,
                                     self.target_log.html_table_style,
                                     index=index)
-            except ModuleNotFoundError:  # pragma: no-cover
+            # pragma: no-cover
+            except ModuleNotFoundError:
                 html_code = df.to_html(index=index)
         else:
             html_code = df.to_html(index=index)
@@ -467,7 +468,8 @@ class VisualLogBuilder:
                                    tablefmt=self.target_log.txt_table_format) +
                     "\n")
                 return
-            except ModuleNotFoundError:  # pragma: no-cover
+            # pragma: no-cover
+            except ModuleNotFoundError:
                 pass
         else:
             string_table = df.to_string(index=index) + "\n"
@@ -641,6 +643,7 @@ class VisualLogBuilder:
 
         :return: The backup data
         """
+        self.flush()
         if HTML not in self.target_log.log_formats:
             raise ValueError("At the moment only HTML backup is supported")
         return VisualLogBackup(data=self.target_log.get_body(HTML))

--- a/scistag/vislog/visual_log_table_builder.py
+++ b/scistag/vislog/visual_log_table_builder.py
@@ -29,20 +29,67 @@ class VisualLogTableContext(VisualLogElementContext):
     Automatically adds the beginning and ending of a table to the log
     """
 
-    def __init__(self, builder: "VisualLogBuilder"):
+    def __init__(self, builder: "VisualLogBuilder",
+                 size: tuple[int, int] | None = None):
         """
         :param builder: The builder object with which we write to the log
+        :param size: The table's dimensions (cols x rows) (if known in advance).
+
+            If provided you can fill the table's contents via
+            ..  code-block: python
+
+                for row in vl.table.begin(size=(3,3)):
+                    for col in row:
+                        ...
+        """
+        self.size = size
+        """
+        The count of table rows and columns
         """
         log = builder.target_log
         log.write_html(f'<table class="log_table">')
         log.write_txt("\n", md=False)
         log.write_md("<table>")
+        self._entered: bool = False
+        "Defines if the table was entered already"
         closing_code = {"html": "</table><br>", "md": "</table><br>",
                         "txt": "\n"}
         super().__init__(builder, closing_code)
 
     def __enter__(self) -> VisualLogTableContext:
+        if self._entered:
+            return
+        self._entered = True
         return self
+
+    def __iter__(self) -> "VisualLogTableRowIterator":
+        """
+        Iterates through the table's rows. Requires that the table's size is
+        defined. See table.begin(size=..)).
+
+        :return: The row iterator
+        """
+        if self.size is None or self.size[0] is None:
+            raise ValueError("Table column size not defined. Pass the size "
+                             "argument to the table when creating it.")
+        return self.iter_rows(self.size[1])
+
+    def iter_rows(self, count: int) -> "VisualLogTableRowIterator":
+        """
+        Creates a row iterator which calls ddd_row for the count of rows
+        defined.
+
+        Usage:
+        ..  code-block: python
+
+            for row in vl.table.begin().iter_rows(8):
+                ...
+
+        :param count: Tne number of rows
+        :return: The iterator object
+        """
+        iterator = VisualLogTableRowIterator(self, count=count)
+        return iterator
 
     def add_row(self, content: list[ColumnContent] | None = None) \
             -> Union["VisualLogRowContext", None]:
@@ -69,7 +116,96 @@ class VisualLogTableContext(VisualLogElementContext):
                 self.builder.html("</td>")
             self.builder.html("</tr>")
             return None
-        return VisualLogRowContext(self.builder)
+        return VisualLogRowContext(self)
+
+
+class VisualLogTableRowIterator:
+    """
+    Iterates through a set of defined rows of a VisualLogTableContext
+    """
+
+    def __init__(self, table: VisualLogTableContext, count: int):
+        self.table = table
+        """
+        The table to which the row shall be added
+        """
+        self.row_count = count
+        """
+        The count of rows
+        """
+        self.index = 0
+        """
+        The current index
+        """
+        self.previous_row: VisualLogRowContext = None
+        """
+        The previous row (... we need to close upon starting the next element)
+        """
+
+    def __iter__(self) -> VisualLogTableRowIterator:
+        """
+        Returns self
+        """
+        return self
+
+    def __next__(self) -> VisualLogTableRowIterator:
+        """
+        Starts the next row and enters it, leaves the previous one (if any)
+        """
+        import sys
+        if self.previous_row:
+            self.previous_row.__exit__(*sys.exc_info())
+        if self.index >= self.row_count:
+            self.table.__exit__(*sys.exc_info())
+            raise StopIteration
+        self.index += 1
+        row = VisualLogRowContext(self.table)
+        self.previous_row = row
+        return row.__enter__()
+
+
+class VisualLogTableColIterator:
+    """
+    Iterates through a set of defined rows of a VisualLogTableContext
+    """
+
+    def __init__(self, row: "VisualLogRowContext", count: int):
+        self.row = row
+        """
+        The table to which the column shall be added
+        """
+        self.col_count = count
+        """
+        The count of rows
+        """
+        self.index = 0
+        """
+        The current index
+        """
+        self.previous_col: VisualLogColContext = None
+        """
+        The previous col (... we need to close upon starting the next element)
+        """
+
+    def __iter__(self) -> VisualLogTableColIterator:
+        """
+        Returns self
+        """
+        return self
+
+    def __next__(self) -> VisualLogTableColIterator:
+        """
+        Starts the next column and enters it, leaves the previous one (if any)
+        """
+        import sys
+        if self.previous_col:
+            self.previous_col.__exit__(*sys.exc_info())
+        if self.index >= self.col_count:
+            raise StopIteration
+        self.index += 1
+        col = VisualLogColumnContext(self.row.builder)
+        self.previous_col = col
+        return col.__enter__()
 
 
 class VisualLogRowContext(VisualLogElementContext):
@@ -77,19 +213,32 @@ class VisualLogRowContext(VisualLogElementContext):
     Automatically adds the beginning and ending of a row to the log
     """
 
-    def __init__(self, builder: "VisualLogBuilder"):
+    def __init__(self, table: "VisualLogTableContext"):
         """
         :param builder: The builder object with which we write to the log
         """
-        log = builder.target_log
+        self.table = table
+        log = self.table.builder.target_log
         log.write_html(f'<tr>\n')
         log.write_txt("| ", md=False)
         log.write_md("<tr>\n", no_break=True)
         closing_code = {"html": "</tr>", "md": "</tr>", "txt": "\n"}
-        super().__init__(builder, closing_code)
+        super().__init__(table.builder, closing_code)
 
     def __enter__(self) -> VisualLogRowContext:
         return self
+
+    def __iter__(self):
+        """
+        Iterates through the row's columns. Requires that the table's size is
+        defined. See table.begin(size=..)).
+
+        :return: The column iterator
+        """
+        if self.table.size is None or self.table.size[0] is None:
+            raise ValueError("Table column size not defined. Pass the size "
+                             "argument to the table when creating it.")
+        return self.iter_cols(self.table.size[0])
 
     def add_col(self,
                 content: ColumnContent | None = None,
@@ -118,6 +267,24 @@ class VisualLogRowContext(VisualLogElementContext):
             return None
 
         return VisualLogColumnContext(self.builder)
+
+    def iter_cols(self, count: int) -> "VisualLogTableColIterator":
+        """
+        Creates a column iterator which calls ddd_col for the count of columns
+        defined.
+
+        Usage:
+        ..  code-block: python
+
+            for row in vl.table.begin().iter_rows(8):
+                for col in row.iter_cols(4):
+                    ...
+
+        :param count: Tne number of columns
+        :return: The iterator object
+        """
+        iterator = VisualLogTableColIterator(self, count=count)
+        return iterator
 
 
 class VisualLogColumnContext(VisualLogElementContext):
@@ -152,7 +319,7 @@ class VisualLogTableBuilderExtension(VisualLogBuilderExtension):
         super().__init__(builder)
         self.show = self.__call__
 
-    def begin(self):
+    def begin(self, size: tuple[int, int] | None = None):
         """
         Creates a table logging context
 
@@ -165,9 +332,17 @@ class VisualLogTableBuilderExtension(VisualLogBuilderExtension):
                             with row.add_col():
                                 vl.log(col_index)
 
+        :param size: The table's dimensions (cols x rows) (if known in advance)
+
+            If provided you can fill the table's contents via
+            ..  code-block: python
+
+                for row in vl.table.begin(size=(3,3)):
+                    for col in row:
+                        ...
         :return: The logging context
         """
-        return VisualLogTableContext(self.builder)
+        return VisualLogTableContext(self.builder, size=size)
 
     def __call__(self, data: list[list[any]], index=False, header=False):
         """


### PR DESCRIPTION
* Added the possibility to render polygons using the Canvas class
* Added supported for PyCharm 3.11 (thanks to PyArrow now supporting it)
* Added the possibility to explicitly pass the image format to VisualLogBuilder.image
* Lists with up to three numeric values logged using VisualLogBuilder.log_dict or log_list are now visualized in a single line
* Renamed the Canvas initializer parameter image_format to format to be consistent to other classes
* Finished integration of running a VisualLog as standalone app
* Add the class VisualLogBackgroundHandler which can execute the VisualLog logic in a background thread, e.g. to hand over the main thread to an UI application
* Optimized AzureFileSink tests
* Made it easier to embed logs from another process into the main log via (VisualLogBuilder.create_backup and insert_backup
* Added a default footer to VisualLog
* Added the possibility to open a local report in the browser if the log is generated via VisualLog.run
* Added the possibility to render lines and circles to Canvas
* Enhanced unit tests for Canvas and VisualLogBuilder
* Added unit tests for new color conversion functions for class Color
* Added testing functions for logging tables in VisualLog with different approaches (iterators, direct adding of whole tables, cols or rows)
* The pixel_format of an image can now also be passed as string literal